### PR TITLE
Fix assign for other definitions of Task

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
   "tasks": {
-    "dev": "deno run --watch main.ts"
+    "dev": "deno run --watch src/index.ts"
   }
 }

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -341,7 +341,7 @@ export class Task<E, T> {
     other: Task<E, A> | ((t: T) => Task<E, A>)
   ): Task<E, T & { [k in K]: A }> {
     return this.andThen((t) => {
-      const task = other instanceof Task ? other : other(t);
+      const task = typeof other === 'function' ? other(t) : other;
       return task.map<T & { [k in K]: A }>((a) => ({
         ...Object(t),
         [k.toString()]: a,


### PR DESCRIPTION
Same fix as https://github.com/kofno/maybeasy/pull/20 applied to `Task.assign`.